### PR TITLE
Add devcontainer-bridge (dbr) for dynamic port forwarding

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -17,8 +17,8 @@
 - **`/ship`** — Combined commit/push/PR command with full code review, commit message approval, and AskUserQuestion confirmation before PR creation; optionally links to tickets if context exists
 - **`/pr:review`** — Review any PR by number/URL or auto-detect from current branch; posts findings as PR comment with severity ratings; never approves or merges
 
-#### Port Forwarding
-- **devcontainer-bridge (dbr)** — Dynamic port auto-discovery and forwarding independent of VS Code. Container daemon polls for new listeners and forwards them to the host via reverse TCP connections. Requires `dbr host-daemon` running on the host machine. See [devcontainer-bridge](https://github.com/bradleybeddoes/devcontainer-bridge)
+#### Features
+- **devcontainer-bridge (dbr)** — Ports opened inside the container are now automatically discovered and forwarded to the host, even outside VS Code. Requires `dbr host-daemon` running on the host. See [devcontainer-bridge](https://github.com/bradleybeddoes/devcontainer-bridge)
 
 ### Changed
 

--- a/.devcontainer/CLAUDE.md
+++ b/.devcontainer/CLAUDE.md
@@ -183,7 +183,7 @@ Two mechanisms handle port access:
 
 | Mechanism | When Active | Dynamic Discovery |
 |-----------|-------------|-------------------|
-| `forwardPorts` (devcontainer.json) | VS Code / Codespaces only | Yes (VS Code auto-detect) |
+| `forwardPorts` (devcontainer.json) | VS Code / Codespaces only | No (static list; VS Code auto-detects separately) |
 | devcontainer-bridge (`dbr`) | Any terminal client | Yes (polls `/proc/net/tcp`) |
 
 `forwardPorts` is a no-op outside VS Code — the `devcontainer` CLI ignores it. `dbr` provides VS Code-independent dynamic port discovery via a reverse connection model (container→host). The container daemon auto-starts and is inert without the host daemon (`dbr host-daemon`). Both mechanisms coexist. See [devcontainer-bridge](https://github.com/bradleybeddoes/devcontainer-bridge).

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -150,7 +150,7 @@
 			"enableBell": true,
 			"enableOsc": true
 		},
-		"ghcr.io/bradleybeddoes/devcontainer-bridge/dbr:latest": {}
+		"ghcr.io/bradleybeddoes/devcontainer-bridge/dbr:0.2.0": {}
 	},
 
 	"forwardPorts": [7847],


### PR DESCRIPTION
## Summary

- Adds [devcontainer-bridge](https://github.com/bradleybeddoes/devcontainer-bridge) (`dbr`) as an external devcontainer feature
- Provides dynamic port auto-discovery independent of VS Code (polls `/proc/net/tcp`, reverse TCP forwarding to host)
- Container daemon is inert without host-side `dbr host-daemon` — VS Code users unaffected
- `forwardPorts` retained for VS Code notify UX; both mechanisms coexist

## Changes

- `devcontainer.json` — added `ghcr.io/bradleybeddoes/devcontainer-bridge/dbr:latest` to features and install order
- `CHANGELOG.md` — added `[Unreleased]` entry
- `CLAUDE.md` — added `dbr` command and Port Forwarding section

## Test plan

- [ ] Rebuild container — verify `which dbr` returns a path
- [ ] `dbr container-daemon --help` works inside container
- [ ] Without host daemon: container daemon backs off silently, no errors
- [ ] With host daemon on host: ports auto-discovered and forwarded
- [ ] VS Code `forwardPorts` still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced devcontainer-bridge (dbr) for dynamic port discovery and forwarding outside VS Code.
  * Added a new dbr command for host-aware port forwarding.

* **Documentation**
  * Expanded port forwarding docs with activation contexts, dynamic discovery behavior, and coexistence guidance.
  * Noted host-daemon requirement and added changelog Unreleased entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->