### PR TITLE
Default to opus-4-5, add cc7/ccw7/cc-orc7 for opus-4-7

### DIFF
--- a/container/.devcontainer/AGENTS.md
+++ b/container/.devcontainer/AGENTS.md
@@ -22,11 +22,12 @@ Config files deploy via `defaults/codeforge/file-manifest.json` on every contain
 
 | Command | Purpose |
 |---------|---------|
-| `cc` / `claude` | Run Claude Code with auto-configuration |
+| `cc` / `claude` | Run Claude Code with auto-configuration (opus-4-5, 200k context) |
 | `codeforge config apply` | Deploy config files to `~/.claude/` (same as container start) |
 | `ccraw` | Vanilla Claude Code (bypasses config) |
-| `ccw` | Claude Code with writing system prompt |
-| `cc-orc` | Claude Code in orchestrator mode (delegation-first) |
+| `ccw` | Claude Code with writing system prompt (opus-4-5, 200k context) |
+| `cc-orc` | Claude Code in orchestrator mode, delegation-first (opus-4-5, 200k context) |
+| `cc7` / `ccw7` / `cc-orc7` | Claude Code on opus-4-7 with 400k context (main / writing / orchestrator modes) |
 | `codex` | OpenAI Codex CLI terminal coding agent |
 | `ccms` | Session history search _(disabled — requires Rust toolchain; uncomment in devcontainer.json to enable)_ |
 | `codeforge proxy` | Launch Claude Code through mitmproxy — inspect API traffic in browser (port 8081) |

--- a/container/.devcontainer/CHANGELOG.md
+++ b/container/.devcontainer/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Configuration
 
+- **Default model changed to `claude-opus-4-5`** — `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL` in default settings flipped from `claude-opus-4-7` to `claude-opus-4-5`. Subagents also run on 4.5 by default.
+- **Per-alias context windows** — `CLAUDE_CODE_MAX_CONTEXT_TOKENS` and `CLAUDE_CODE_AUTO_COMPACT_WINDOW` removed from global `settings.json env` (they pinned 250k globally, which would exceed 4.5's 200k ceiling). Context is now set inline per alias: `cc` / `claude` / `ccw` / `cc-orc` = 200k; `cc7` / `ccw7` / `cc-orc7` = 400k.
+- **New 4.7 alias variants** — `cc7`, `ccw7`, `cc-orc7` run Claude Code on `claude-opus-4-7` with a 400k context window (main / writing / orchestrator system prompts respectively). Use these for sessions that need 4.7's larger window; use `cc` / `ccw` / `cc-orc` (now on 4.5) for standard work.
 - **Thinking display set to summarized** — `cc`, `claude`, `ccw`, and `cc-orc` aliases now pass `--thinking-display summarized`, keeping the terminal tidy while still surfacing thinking. `ccraw` is unaffected (stays vanilla).
 - **View mode set to focus** — `viewMode` changed from `verbose` to `focus` in default settings for a cleaner terminal UI.
 

--- a/container/.devcontainer/defaults/codeforge/config/settings.json
+++ b/container/.devcontainer/defaults/codeforge/config/settings.json
@@ -3,8 +3,8 @@
 	"autoCompact": true,
 	"alwaysThinkingEnabled": true,
 	"env": {
-		"ANTHROPIC_MODEL": "claude-opus-4-7",
-		"ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-7",
+		"ANTHROPIC_MODEL": "claude-opus-4-5",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-5",
 		"ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
 		"ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5-20251001",
 		"BASH_DEFAULT_TIMEOUT_MS": "120000",
@@ -18,8 +18,6 @@
 		"MCP_TOOL_TIMEOUT": "30000",
 		"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "80",
 		"FORCE_AUTOUPDATE_PLUGINS": "1",
-		"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "250000",
-		"CLAUDE_CODE_MAX_CONTEXT_TOKENS": "250000",
 		"CLAUDE_CODE_SCROLL_SPEED": "3",
 
 		"ENABLE_TOOL_SEARCH": "auto:5",

--- a/container/.devcontainer/scripts/setup-aliases.sh
+++ b/container/.devcontainer/scripts/setup-aliases.sh
@@ -61,6 +61,9 @@ for rc in ~/.bashrc ~/.zshrc; do
 		sed -i "/^alias claude='/d" "$rc"
 		sed -i "/^alias ccraw='/d" "$rc"
 		sed -i "/^alias ccw='/d" "$rc"
+		sed -i "/^alias cc7='/d" "$rc"
+		sed -i "/^alias ccw7='/d" "$rc"
+		sed -i "/^alias cc-orc7='/d" "$rc"
 		sed -i '/^alias check-setup=/d' "$rc"
 		# cc-tools function from old format
 		if grep -q "^cc-tools()" "$rc" 2>/dev/null; then
@@ -114,11 +117,14 @@ _OMC_DISALLOWED_TOOLS=(
     mcp__oh-my-claude__coworker_task
 )
 
-alias cc='CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/main-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
-alias claude='CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/main-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias cc='CLAUDE_CODE_MAX_CONTEXT_TOKENS=200000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/main-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias claude='CLAUDE_CODE_MAX_CONTEXT_TOKENS=200000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/main-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
 alias ccraw='command "\$_CLAUDE_BIN"'
-alias ccw='CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/writing-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
-alias cc-orc='CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias ccw='CLAUDE_CODE_MAX_CONTEXT_TOKENS=200000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/writing-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias cc-orc='CLAUDE_CODE_MAX_CONTEXT_TOKENS=200000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=200000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --system-prompt-file "\$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias cc7='CLAUDE_CODE_MAX_CONTEXT_TOKENS=400000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --model claude-opus-4-7 --system-prompt-file "\$CLAUDE_CONFIG_DIR/main-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias ccw7='CLAUDE_CODE_MAX_CONTEXT_TOKENS=400000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --model claude-opus-4-7 --system-prompt-file "\$CLAUDE_CONFIG_DIR/writing-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
+alias cc-orc7='CLAUDE_CODE_MAX_CONTEXT_TOKENS=400000 CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000 CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD=1 "\$_CLAUDE_WRAP" "\$_CLAUDE_BIN" --model claude-opus-4-7 --system-prompt-file "\$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md" --permission-mode plan --allow-dangerously-skip-permissions --thinking-display summarized "\${_OMC_DISALLOWED_TOOLS[@]}"'
 alias ccr-apply='codeforge config apply && (ccr restart 2>/dev/null || ccr start) && echo "CCR config applied and restarted"'
 alias omc-apply='codeforge config apply && (omc proxy restart 2>/dev/null || omc proxy start) && echo "OMC config applied and proxy restarted"'
 
@@ -149,11 +155,14 @@ BLOCK_EOF
 done
 
 echo "[setup-aliases] Aliases configured:"
-echo "  cc          -> claude with \$CLAUDE_CONFIG_DIR/main-system-prompt.md"
-echo "  claude      -> claude with \$CLAUDE_CONFIG_DIR/main-system-prompt.md"
+echo "  cc          -> claude (opus-4-5, 200k ctx) with \$CLAUDE_CONFIG_DIR/main-system-prompt.md"
+echo "  claude      -> claude (opus-4-5, 200k ctx) with \$CLAUDE_CONFIG_DIR/main-system-prompt.md"
 echo "  ccraw       -> vanilla claude without any config"
-echo "  ccw         -> claude with \$CLAUDE_CONFIG_DIR/writing-system-prompt.md"
-echo "  cc-orc      -> claude with \$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md (delegation mode)"
+echo "  ccw         -> claude (opus-4-5, 200k ctx) with \$CLAUDE_CONFIG_DIR/writing-system-prompt.md"
+echo "  cc-orc      -> claude (opus-4-5, 200k ctx) with \$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md (delegation mode)"
+echo "  cc7         -> claude (opus-4-7, 400k ctx) with \$CLAUDE_CONFIG_DIR/main-system-prompt.md"
+echo "  ccw7        -> claude (opus-4-7, 400k ctx) with \$CLAUDE_CONFIG_DIR/writing-system-prompt.md"
+echo "  cc-orc7     -> claude (opus-4-7, 400k ctx) with \$CLAUDE_CONFIG_DIR/orchestrator-system-prompt.md (delegation mode)"
 echo "  ccr-apply   -> redeploy claude-code-router config + restart daemon"
 echo "  cc-tools    -> list all available CodeForge tools"
 echo "  check-setup -> verify CodeForge setup health"


### PR DESCRIPTION
## Summary

- Flip default Opus model to `claude-opus-4-5`. `ANTHROPIC_MODEL` and `ANTHROPIC_DEFAULT_OPUS_MODEL` in `settings.json` change from `claude-opus-4-7` → `claude-opus-4-5` (subagents run on 4.5 too).
- Move context-window control out of global `env` (was pinning 250k, would exceed 4.5's 200k API ceiling) and inline per alias: `cc` / `claude` / `ccw` / `cc-orc` = 200k; new `cc7` / `ccw7` / `cc-orc7` = 400k on `claude-opus-4-7`.
- Thinking env vars (`MAX_THINKING_TOKENS`, `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING`, `CLAUDE_CODE_EFFORT_LEVEL`) stay global by decision — accepted risk that 4.7-tuned budgets also apply to 4.5 sessions. `ccraw` unchanged.

## Files changed

- `container/.devcontainer/defaults/codeforge/config/settings.json` — 2 model flips, 2 context-window removals
- `container/.devcontainer/scripts/setup-aliases.sh` — inline env prefix on 4 existing aliases, 3 new 4.7 aliases, 3 legacy-cleanup `sed` entries, updated status echo
- `container/.devcontainer/CHANGELOG.md` — v2.2.1 Configuration entries
- `container/.devcontainer/AGENTS.md` — Commands table updated

## Test plan

- [ ] `cd container/.devcontainer && codeforge config apply` deploys updated `settings.json`
- [ ] `source ~/.bashrc` (or new terminal) reloads aliases
- [ ] `alias cc cc7 ccw ccw7 cc-orc cc-orc7` — 4.5 aliases contain `200000`, 4.7 aliases contain `400000` and `--model claude-opus-4-7`
- [ ] `cc` session → `/model` confirms `claude-opus-4-5`
- [ ] `cc7` session → `/model` confirms `claude-opus-4-7`
- [ ] Long `cc` session auto-compacts near 80% × 200k = 160k; `cc7` near 80% × 400k = 320k
- [ ] Subagent from `cc` session also runs on 4.5 (verify via session metadata)
- [ ] `cc7` triggers 400k-context `anthropic-beta` header (via `codeforge session tokens` / proxy inspection); if not, follow up with explicit beta header env var

## Rollback

Single-commit revert on these four files + `codeforge config apply && source ~/.bashrc`.