### PR TITLE
fix(container): add git safe.directory to setup.sh

### DIFF
--- a/container/.devcontainer/CHANGELOG.md
+++ b/container/.devcontainer/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Shell terminal keybinds hardened** — disabled `Ctrl+Z` (suspend, which closes Docker-attached panes), `Ctrl+S/Q` (flow control freeze), and `Ctrl+W` (conflicts with Windows Terminal close-tab). Rebound `Ctrl+\` (SIGQUIT) to `Ctrl+]` and `Ctrl+D` (EOF) to `Ctrl+^` as emergency-only alternatives. Also unbound zsh's `Alt+W` (copy-region-as-kill) and `Alt+Q` (push-line) to free those keys for terminal use.
 
+### Security
+
+- **Git safe.directory configured on container start** — bind-mounted `/workspaces` may have a different uid than the container user, causing Git to refuse all operations with "dubious ownership" errors (CVE-2022-24765). `setup.sh` now runs `git config --global safe.directory` using `$WORKSPACE_ROOT` on every start.
+
 ### Hermes Agent
 
 - **New feature: `hermes-agent`** — installs [Nous Research's Hermes Agent](https://hermes-agent.nousresearch.com/) CLI via the upstream `curl | bash` installer with `--skip-setup`. Hermes uses the plain `anthropic` / `openai` Python SDKs directly and supports any compatible provider (Anthropic, OpenAI, MiniMax, local models). Enabled by default; set `"version": "none"` in `devcontainer.json` to disable.

--- a/container/.devcontainer/scripts/setup.sh
+++ b/container/.devcontainer/scripts/setup.sh
@@ -78,7 +78,9 @@ fi
 # Mark workspace as safe for Git — bind-mounted workspace may have
 # different uid than container user, causing "dubious ownership"
 # errors (CVE-2022-24765)
-git config --global safe.directory "${WORKSPACE_ROOT:-/workspaces}"
+if ! git config --global --add safe.directory "${WORKSPACE_ROOT:-/workspaces}" 2>/dev/null; then
+    echo "[setup] WARNING: Could not configure git safe.directory — git operations may show 'dubious ownership' errors"
+fi
 
 SETUP_START=$(date +%s)
 SETUP_RESULTS=()

--- a/container/.devcontainer/scripts/setup.sh
+++ b/container/.devcontainer/scripts/setup.sh
@@ -75,6 +75,11 @@ if ! sudo chown "$(id -un):$(id -gn)" "$HOME/.claude" 2>/dev/null; then
     echo "[setup] WARNING: Could not fix volume ownership on $HOME/.claude — subsequent scripts may fail"
 fi
 
+# Mark workspace as safe for Git — bind-mounted workspace may have
+# different uid than container user, causing "dubious ownership"
+# errors (CVE-2022-24765)
+git config --global safe.directory "${WORKSPACE_ROOT:-/workspaces}"
+
 SETUP_START=$(date +%s)
 SETUP_RESULTS=()
 


### PR DESCRIPTION
## Summary

- Adds `git config --global safe.directory` to `setup.sh`, running on every container start before setup stages
- Fixes "dubious ownership" errors (CVE-2022-24765) caused by uid mismatch between container user and bind-mounted `/workspaces`
- Uses `${WORKSPACE_ROOT:-/workspaces}` for consistency with existing `setup.sh` patterns

## Test plan

- [ ] Rebuild the container
- [ ] Run `git config --global --get-all safe.directory` — should output `/workspaces`
- [ ] `cd` into any project under `/workspaces` and run `git status` — no "dubious ownership" error