### PR TITLE
fix(container): harden shell terminal keybinds for Docker-attached panes

### DIFF
--- a/container/.devcontainer/CHANGELOG.md
+++ b/container/.devcontainer/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Terminal
 
-- **Shell terminal keybinds hardened** — disabled `Ctrl+Z` (suspend, which closes Docker-attached panes), `Ctrl+S/Q` (flow control freeze), and `Ctrl+W` (conflicts with Windows Terminal close-tab). Rebound `Ctrl+\` (SIGQUIT) to `Ctrl+]` and `Ctrl+D` (EOF) to `Ctrl+^` as emergency-only alternatives.
+- **Shell terminal keybinds hardened** — disabled `Ctrl+Z` (suspend, which closes Docker-attached panes), `Ctrl+S/Q` (flow control freeze), and `Ctrl+W` (conflicts with Windows Terminal close-tab). Rebound `Ctrl+\` (SIGQUIT) to `Ctrl+]` and `Ctrl+D` (EOF) to `Ctrl+^` as emergency-only alternatives. Also unbound zsh's `Alt+W` (copy-region-as-kill) and `Alt+Q` (push-line) to free those keys for terminal use.
 
 ### Hermes Agent
 

--- a/container/.devcontainer/CHANGELOG.md
+++ b/container/.devcontainer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Terminal
+
+- **Shell terminal keybinds hardened** — disabled `Ctrl+Z` (suspend, which closes Docker-attached panes), `Ctrl+S/Q` (flow control freeze), and `Ctrl+W` (conflicts with Windows Terminal close-tab). Rebound `Ctrl+\` (SIGQUIT) to `Ctrl+]` and `Ctrl+D` (EOF) to `Ctrl+^` as emergency-only alternatives.
+
 ### Hermes Agent
 
 - **New feature: `hermes-agent`** — installs [Nous Research's Hermes Agent](https://hermes-agent.nousresearch.com/) CLI via the upstream `curl | bash` installer with `--skip-setup`. Hermes uses the plain `anthropic` / `openai` Python SDKs directly and supports any compatible provider (Anthropic, OpenAI, MiniMax, local models). Enabled by default; set `"version": "none"` in `devcontainer.json` to disable.

--- a/container/.devcontainer/scripts/setup-aliases.sh
+++ b/container/.devcontainer/scripts/setup-aliases.sh
@@ -117,9 +117,11 @@ stty werase undef    # Kill Ctrl+W — conflicts with Windows Terminal close-tab
 stty quit '^]'       # Rebind Ctrl+\ (SIGQUIT) → Ctrl+] (emergency only)
 stty eof '^^'        # Rebind Ctrl+D (EOF) → Ctrl+^ (emergency only)
 # zsh bindkey cleanup — stty handles the terminal layer, but zsh's line
-# editor has its own Ctrl+W binding that bypasses stty
+# editor has its own bindings that bypass stty or conflict with pane hotkeys
 if [ -n "\$ZSH_VERSION" ]; then
-    bindkey -r '^W'  # Remove backward-kill-word (stty werase already disabled)
+    bindkey -r '^W'   # Remove backward-kill-word (stty werase already disabled)
+    bindkey -r '^[w'  # Remove copy-region-as-kill (unused emacs kill-ring op)
+    bindkey -r '^[q'  # Remove push-line (niche; frees Alt+Q for terminal use)
 fi
 
 # Native binary (installed by claude-code-native feature)

--- a/container/.devcontainer/scripts/setup-aliases.sh
+++ b/container/.devcontainer/scripts/setup-aliases.sh
@@ -108,6 +108,20 @@ if [ "\$TERM" = "xterm" ] || [ -z "\$TERM" ]; then
 fi
 export COLORTERM="\${COLORTERM:-truecolor}"
 
+# Terminal keybind hardening — disable signals that cause problems in
+# Docker-attached panes (suspend closes pane, flow-control freezes
+# terminal). EOF and QUIT rebound to esoteric combos for emergency use.
+stty susp undef      # Kill Ctrl+Z — suspend closes Docker-attached panes
+stty -ixon           # Kill Ctrl+S/Q — flow control freezes terminal
+stty werase undef    # Kill Ctrl+W — conflicts with Windows Terminal close-tab
+stty quit '^]'       # Rebind Ctrl+\ (SIGQUIT) → Ctrl+] (emergency only)
+stty eof '^^'        # Rebind Ctrl+D (EOF) → Ctrl+^ (emergency only)
+# zsh bindkey cleanup — stty handles the terminal layer, but zsh's line
+# editor has its own Ctrl+W binding that bypasses stty
+if [ -n "\$ZSH_VERSION" ]; then
+    bindkey -r '^W'  # Remove backward-kill-word (stty werase already disabled)
+fi
+
 # Native binary (installed by claude-code-native feature)
 _CLAUDE_BIN="\$HOME/.local/bin/claude"
 


### PR DESCRIPTION
## Summary

- **Disabled problematic terminal signals** — `Ctrl+Z` (suspend, closes Docker-attached panes), `Ctrl+S/Q` (flow control freeze), `Ctrl+W` (conflicts with Windows Terminal close-tab)
- **Rebound SIGQUIT and EOF** — `Ctrl+\` → `Ctrl+]` and `Ctrl+D` → `Ctrl+^` as emergency-only alternatives
- **zsh-specific cleanup** — conditional `bindkey -r` to remove zsh line-editor bindings that bypass stty: `Ctrl+W` (backward-kill-word), `Alt+W` (copy-region-as-kill), `Alt+Q` (push-line)

All config lives in the managed block in `setup-aliases.sh` — idempotent, rewritten on every container start.

## Test plan

- [ ] Open a terminal in the container (VS Code or `docker exec`)
- [ ] Run `stty -a` — verify `susp = <undef>`, `werase = <undef>`, `quit = ^\]`, `eof = ^\^`, no `ixon`
- [ ] Press `Ctrl+Z` — nothing should happen
- [ ] Press `Ctrl+S` — terminal should NOT freeze
- [ ] Press `Ctrl+W` — should NOT delete a word
- [ ] Press `Alt+W` — nothing should happen (zsh)
- [ ] Press `Alt+Q` — nothing should happen (zsh)
- [ ] Press `Ctrl+^` — sends EOF (in `cat`, terminates input)
- [ ] Press `Ctrl+]` — sends SIGQUIT (in `cat`, shows `^\`)
- [ ] Verify `Ctrl+C` still works (SIGINT unaffected)