### PR TITLE
deps(cli): bump @devcontainers/cli, @types/node, and typescript

### DIFF
--- a/cli/bun.lock
+++ b/cli/bun.lock
@@ -5,32 +5,36 @@
     "": {
       "name": "codeforge-cli",
       "dependencies": {
-        "@devcontainers/cli": "^0.71.0",
+        "@devcontainers/cli": "^0.86.1",
         "chalk": "^5.4.0",
-        "commander": "^13.0.0",
+        "commander": "^14.0.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.10",
-        "@types/node": "^22.0.0",
-        "typescript": "^5.7.0",
+        "@types/node": "^25.6.1",
+        "typescript": "^6.0.3",
       },
     },
   },
   "packages": {
-    "@devcontainers/cli": ["@devcontainers/cli@0.71.0", "", { "bin": { "devcontainer": "devcontainer.js" } }, "sha512-My13mDQCZy4zFsIoU2LVdnm3g2oSvxAkp+Z1gO/cYBYG3YUdteIEGm43igq67WPEpdJqE3LjKkIKp4I6fJBzEQ=="],
+    "@devcontainers/cli": ["@devcontainers/cli@0.86.1", "", { "bin": { "devcontainer": "devcontainer.js" } }, "sha512-4VVJR/9Cuvkdg3uOD6nTspnZzpxqjeaQ7YzQjlSnX3lyb+LUeyO8SVdHa24KNBPp5xNu8PWq6aRY5k1KILwyHQ=="],
 
     "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
 
-    "@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
-    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "bun-types/@types/node": ["@types/node@22.19.13", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -28,14 +28,14 @@
 		"prepublishOnly": "bun run build && bun test"
 	},
 	"dependencies": {
-		"@devcontainers/cli": "^0.71.0",
+		"@devcontainers/cli": "^0.86.1",
 		"commander": "^14.0.3",
 		"chalk": "^5.4.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.3.10",
-		"@types/node": "^22.0.0",
-		"typescript": "^5.7.0"
+		"@types/node": "^25.6.1",
+		"typescript": "^6.0.3"
 	},
 	"engines": {
 		"node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- `@devcontainers/cli`: ^0.71.0 → ^0.86.1
- `@types/node`: ^22.0.0 → ^25.6.1
- `typescript`: ^5.7.0 → ^6.0.3

Supersedes #86, #85, #79 (which conflicted after retargeting to staging).

## Verification
- `bun install` ✅
- `bun test` — 336 tests passed, 0 failures ✅